### PR TITLE
feat: add storj ingestion endpoint

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -45,6 +45,9 @@ jobs:
       #   run: |
       #     cargo fmt --check
       #     cargo clippy --no-deps --all-features --release -- -Dwarnings
+      - name: Use rust cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Build
         run: cargo build --release --target x86_64-unknown-linux-musl
         env:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -26,9 +26,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install prereqs
-        run: |
-          sudo apt-get install protobuf-compiler musl-tools
+      - name: Cache and Install prereqs
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: protobuf-compiler musl-tools
+          version: 1.0 # cache version, for manual invalidation
 
       - name: Rust Setup
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -63,7 +63,7 @@ jobs:
           flyctl secrets set QSTASH_AUTH_TOKEN="$QSTASH_AUTH_TOKEN" --app "$APP_NAME" --stage
           flyctl secrets set ML_FEED_CACHE_REDIS_URL="$ML_FEED_CACHE_REDIS_URL" --app "$APP_NAME" --stage
           flyctl secrets set STORJ_INTERFACE_TOKEN="$STORJ_INTERFACE_TOKEN" --app "$APP_NAME" --stage
-          flyctl secrets deploy --app $APP_NAME
+          flyctl deploy --app $APP_NAME
         env:
           FLY_API_TOKEN: ${{ secrets.HOT_OR_NOT_OFF_CHAIN_AGENT_FLY_IO_GITHUB_ACTION }}
           CF_R2_ACCESS_KEY_TEMP: ${{ secrets.HOT_OR_NOT_OFF_CHAIN_AGENT_CLOUDFLARE_R2_ACCESS_KEY_ID }}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -22,9 +22,10 @@ pub const CLOUDFLARE_ACCOUNT_ID: &str = "a209c523d2d9646cc56227dbe6ce3ede";
 
 pub const ICP_LEDGER_CANISTER_ID: &str = "ryjl3-tyaaa-aaaaa-aaaba-cai";
 
-// TODO: change back to https://icp-off-chain-agent.fly.dev/
+// TODO: make this an environment variable that is set to point to pr deployment
+// url in prs and to prod url when deploying to main
 pub static OFF_CHAIN_AGENT_URL: Lazy<Url> =
-    Lazy::new(|| Url::parse("https://pr-174-yral-dapp-off-chain-agent.fly.dev/").unwrap());
+    Lazy::new(|| Url::parse("https://icp-off-chain-agent.fly.dev/").unwrap());
 
 pub const NSFW_SERVER_URL: &str = "https://prod-yral-nsfw-classification.fly.dev:443";
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -22,8 +22,9 @@ pub const CLOUDFLARE_ACCOUNT_ID: &str = "a209c523d2d9646cc56227dbe6ce3ede";
 
 pub const ICP_LEDGER_CANISTER_ID: &str = "ryjl3-tyaaa-aaaaa-aaaba-cai";
 
+// TODO: change back to https://icp-off-chain-agent.fly.dev/
 pub static OFF_CHAIN_AGENT_URL: Lazy<Url> =
-    Lazy::new(|| Url::parse("https://icp-off-chain-agent.fly.dev/").unwrap());
+    Lazy::new(|| Url::parse("https://pr-174-yral-dapp-off-chain-agent.fly.dev/").unwrap());
 
 pub const NSFW_SERVER_URL: &str = "https://prod-yral-nsfw-classification.fly.dev:443";
 

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -25,6 +25,8 @@ use yral_ml_feed_cache::{
 
 use super::queries::get_icpump_insert_query;
 
+pub mod storj;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct TokenListItem {
     user_id: String,

--- a/src/events/event/storj.rs
+++ b/src/events/event/storj.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use axum::{extract::State, Json};
+
+use crate::{app_state::AppState, AppError};
+
+pub async fn storj_ingest(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<storj_interface::duplicate::Args>,
+) -> Result<(), AppError> {
+    // let client = reqwest::Client::new();
+    // client
+    //     .post(
+    //         STORJ_INTERFACE_URL
+    //             .join("/duplicate")
+    //             .expect("url to be valid"),
+    //     )
+    //     .json(&payload)
+    //     .bearer_auth(STORJ_INTERFACE_TOKEN.as_str())
+    //     .send()
+    //     .await?;
+    //
+    log::info!("test succesful");
+
+    Ok(())
+}
+
+pub async fn enqueue_storj_backfill_item(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<storj_interface::duplicate::Args>,
+) -> Result<(), AppError> {
+    state.qstash_client.duplicate_to_storj(payload).await?;
+
+    Ok(())
+}

--- a/src/events/event/storj.rs
+++ b/src/events/event/storj.rs
@@ -2,29 +2,32 @@ use std::sync::Arc;
 
 use axum::{extract::State, Json};
 
-use crate::{app_state::AppState, AppError};
+use crate::{
+    app_state::AppState,
+    consts::{STORJ_INTERFACE_TOKEN, STORJ_INTERFACE_URL},
+    AppError,
+};
 
 pub async fn storj_ingest(
-    State(state): State<Arc<AppState>>,
     Json(payload): Json<storj_interface::duplicate::Args>,
 ) -> Result<(), AppError> {
-    // let client = reqwest::Client::new();
-    // client
-    //     .post(
-    //         STORJ_INTERFACE_URL
-    //             .join("/duplicate")
-    //             .expect("url to be valid"),
-    //     )
-    //     .json(&payload)
-    //     .bearer_auth(STORJ_INTERFACE_TOKEN.as_str())
-    //     .send()
-    //     .await?;
-    //
-    log::info!("test succesful");
+    let client = reqwest::Client::new();
+    client
+        .post(
+            STORJ_INTERFACE_URL
+                .join("/duplicate")
+                .expect("url to be valid"),
+        )
+        .json(&payload)
+        .bearer_auth(STORJ_INTERFACE_TOKEN.as_str())
+        .send()
+        .await?;
 
     Ok(())
 }
 
+/// for the purpose of backfilling, can be removed once there are no more items
+/// to be filled
 pub async fn enqueue_storj_backfill_item(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<storj_interface::duplicate::Args>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use canister::upload_user_video::upload_user_video_handler;
 use config::AppConfig;
 use consts::STORJ_INTERFACE_TOKEN;
 use env_logger::{Builder, Target};
+use events::event::storj::enqueue_storj_backfill_item;
 use events::nsfw::extract_frames_and_upload;
 use http::header::CONTENT_TYPE;
 use log::LevelFilter;
@@ -120,6 +121,10 @@ async fn main() -> Result<()> {
         .route(
             "/update-global-ml-feed-cache-nsfw",
             get(update_ml_feed_cache_nsfw),
+        )
+        .route(
+            "/enqueue_storj_backfill_item",
+            post(enqueue_storj_backfill_item),
         )
         .nest("/qstash", qstash_routes)
         .nest_service("/", router)

--- a/src/qstash/client.rs
+++ b/src/qstash/client.rs
@@ -42,6 +42,26 @@ impl QStashClient {
         }
     }
 
+    pub async fn duplicate_to_storj(
+        &self,
+        data: storj_interface::duplicate::Args,
+    ) -> anyhow::Result<()> {
+        let off_chain_ep = OFF_CHAIN_AGENT_URL.join("qstash/storj_ingest").unwrap();
+        let url = self.base_url.join(&format!("publish/{}", off_chain_ep))?;
+
+        self.client
+            .post(url)
+            .json(&data)
+            .header(CONTENT_TYPE, "application/json")
+            .header("upstash-method", "POST")
+            .header("Upstash-Flow-Control-Key", "STORJ_INGESTION")
+            .header("Upstash-Flow-Control-Value", "Rate=20,Parallelism=10")
+            .send()
+            .await?;
+
+        Ok(())
+    }
+
     pub async fn publish_video(
         &self,
         video_id: &str,

--- a/src/qstash/mod.rs
+++ b/src/qstash/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     },
     consts::ICP_LEDGER_CANISTER_ID,
     events::{
-        event::upload_video_gcs,
+        event::{storj::storj_ingest, upload_video_gcs},
         nsfw::{extract_frames_and_upload, nsfw_job, nsfw_job_v2},
     },
     posts::qstash_report_post,
@@ -430,6 +430,7 @@ pub fn qstash_router<S>(app_state: Arc<AppState>) -> Router<S> {
             post(upgrade_user_token_sns_canister_for_entire_network),
         )
         .route("/report_post", post(qstash_report_post))
+        .route("/storj_ingest", post(storj_ingest))
         .layer(ServiceBuilder::new().layer(middleware::from_fn_with_state(
             app_state.qstash.clone(),
             verify_qstash_message,


### PR DESCRIPTION
Adds an ingestion endpoint for storj:
- will be used for backfilling over the next couple days using qstash for retries and parallelism
- also addresses a problem pointed out earlier: https://github.com/yral-dapp/off-chain-agent/pull/167#discussion_r2013977712

Additionally:
- adds caching to builds, i have seen reduction from 9mins to 1.5mins on build times
- adds caching for apt installed deps
- fixes a slight issue with the github action's fly secret setup step which breaks the first deployment when a pr opens